### PR TITLE
Use -ContentType parameter in Invoke-WebRequest

### DIFF
--- a/PSJira/Functions/Internal/Invoke-JiraMethod.ps1
+++ b/PSJira/Functions/Internal/Invoke-JiraMethod.ps1
@@ -24,7 +24,7 @@ function Invoke-JiraMethod
     )
 
     $headers = @{
-        'Content-Type' = 'application/json; charset=utf-8';
+        #'Content-Type' = 'application/json; charset=utf-8';
     }
 
     if ($Credential)
@@ -57,16 +57,16 @@ function Invoke-JiraMethod
         if ($session -and $Body)
         {
             Write-Debug "[Invoke-JiraMethod] Invoking JIRA method $Method to URI $URI using WebSession and Body"
-            $webResponse = Invoke-WebRequest -Uri $URI -Headers $headers -Method $Method -Body $cleanBody -WebSession $session.WebSession -ErrorAction SilentlyContinue
+            $webResponse = Invoke-WebRequest -Uri $URI -Headers $headers -Method $Method -Body $cleanBody -WebSession $session.WebSession -ErrorAction SilentlyContinue -ContentType 'application/json; charset=utf-8'
         } elseif ($session) {
             Write-Debug "[Invoke-JiraMethod] Invoking JIRA method $Method to URI $URI using WebSession"
-            $webResponse = Invoke-WebRequest -Uri $URI -Headers $headers -Method $Method -WebSession $session.WebSession -ErrorAction SilentlyContinue
+            $webResponse = Invoke-WebRequest -Uri $URI -Headers $headers -Method $Method -WebSession $session.WebSession -ErrorAction SilentlyContinue -ContentType 'application/json; charset=utf-8'
         } elseif ($Body) {
             Write-Debug "[Invoke-JiraMethod] Invoking JIRA method $Method to URI $URI using Body"
-            $webResponse = Invoke-WebRequest -Uri $URI -Headers $headers -Method $Method -Body $cleanBody -ErrorAction SilentlyContinue
+            $webResponse = Invoke-WebRequest -Uri $URI -Headers $headers -Method $Method -Body $cleanBody -ErrorAction SilentlyContinue -ContentType 'application/json; charset=utf-8'
         } else {
             Write-Debug "[Invoke-JiraMethod] Invoking JIRA method $Method to URI $URI with no WebSession or Body"
-            $webResponse = Invoke-WebRequest -Uri $URI -Headers $headers -Method $Method -ErrorAction SilentlyContinue
+            $webResponse = Invoke-WebRequest -Uri $URI -Headers $headers -Method $Method -ErrorAction SilentlyContinue -ContentType 'application/json; charset=utf-8'
         }
     } catch {
         # Invoke-WebRequest is hard-coded to throw an exception if the Web request returns a 4xx or 5xx error.

--- a/PSJira/Functions/New-JiraSession.ps1
+++ b/PSJira/Functions/New-JiraSession.ps1
@@ -45,7 +45,7 @@ function New-JiraSession
         $uri = "$server/rest/auth/1/session"
 
         $headers = @{
-            'Content-Type' = 'application/json';
+            #'Content-Type' = 'application/json';
         }
     }
 
@@ -62,7 +62,7 @@ function New-JiraSession
 
         try
         {
-            $webResponse = Invoke-WebRequest -Uri $uri -Headers $headers -Method Post -Body $json -SessionVariable newSessionVar
+            $webResponse = Invoke-WebRequest -Uri $uri -Headers $headers -Method Post -Body $json -SessionVariable newSessionVar -ContentType 'application/json'
             Write-Debug "[New-JiraSession] Converting result to JiraSession object"
             $result = ConvertTo-JiraSession -WebResponse $webResponse -Session $newSessionVar -Username $Credential.UserName
 
@@ -81,7 +81,6 @@ function New-JiraSession
             Write-Debug "[New-JiraSession] Outputting result"
             Write-Output $result
         } catch {
-            $err = $_
             $webResponse = $err.Exception.Response
             Write-Debug "[New-JiraSession] Encountered an exception from the Jira server: $err"
 


### PR DESCRIPTION
The Invoke-WebRequest command offers a contenttype parameter. Setting
the content type using the normal headers does not work for me
