### PR TITLE
Take over global PSDefaultParameterValues

### DIFF
--- a/PSJira/Internal/Invoke-JiraMethod.ps1
+++ b/PSJira/Internal/Invoke-JiraMethod.ps1
@@ -23,6 +23,11 @@ function Invoke-JiraMethod
 #        [Object] $Session
     )
 
+    # load DefaultParameters for Invoke-WebRequest
+    # as the global PSDefaultParameterValues is not used
+    # TODO: find out why PSJira doesn't need this
+    $PSDefaultParameterValues = $global:PSDefaultParameterValues
+
     $headers = @{
         'Content-Type' = 'application/json; charset=utf-8';
     }

--- a/PSJira/Public/New-JiraSession.ps1
+++ b/PSJira/Public/New-JiraSession.ps1
@@ -42,6 +42,10 @@ function New-JiraSession
             throw $err
         }
 
+        # load DefaultParameters for Invoke-WebRequest
+        # as the global PSDefaultParameterValues is not used
+        $PSDefaultParameterValues = $global:PSDefaultParameterValues
+
         $uri = "$server/rest/auth/1/session"
 
         $headers = @{


### PR DESCRIPTION
Take over global PSDefaultParameterValues from global scope to local, so that nested function will use the same PSDefaultParameterValues
closes #97