### PR TITLE
Send ContentType as Parameter instead of in the Header

### DIFF
--- a/PSJira/Internal/Invoke-JiraMethod.ps1
+++ b/PSJira/Internal/Invoke-JiraMethod.ps1
@@ -28,9 +28,7 @@ function Invoke-JiraMethod
     # TODO: find out why PSJira doesn't need this
     $PSDefaultParameterValues = $global:PSDefaultParameterValues
 
-    $headers = @{
-        'Content-Type' = 'application/json; charset=utf-8';
-    }
+    $headers = @{}
 
     if ($Credential)
     {
@@ -56,6 +54,7 @@ function Invoke-JiraMethod
         Uri             = $Uri
         Headers         = $headers
         Method          = $Method
+        ContentType     = 'application/json; charset=utf-8'
         UseBasicParsing = $true
         ErrorAction     = 'SilentlyContinue'
     }

--- a/Tests/Invoke-JiraMethod.Tests.ps1
+++ b/Tests/Invoke-JiraMethod.Tests.ps1
@@ -50,7 +50,7 @@ InModuleScope PSJira {
             defParam $command 'Credential'
 
             It "Has a ValidateSet for the -Method parameter that accepts methods [$($validMethods -join ', ')]" {
-                $validateSet = $command.Parameters.Method.Attributes | ? {$_.TypeID -eq [System.Management.Automation.ValidateSetAttribute]}
+                $validateSet = $command.Parameters.Method.Attributes | Where-Object {$_.TypeID -eq [System.Management.Automation.ValidateSetAttribute]}
                 $validateSet.ValidValues | Should Be $validMethods
             }
         }
@@ -80,9 +80,9 @@ InModuleScope PSJira {
                 }
             }
 
-            It "Sends the Content-Type header of application/json and UTF-8" {
+            It "Uses the -ContentType parameter of Invoke-WebRequest to specify application/json and UTF-8" {
                 { Invoke-JiraMethod -Method Get -URI $testUri } | Should Not Throw
-                Assert-MockCalled -CommandName Invoke-WebRequest -ParameterFilter {$Headers.Item('Content-Type') -eq 'application/json; charset=utf-8'} -Scope It
+                Assert-MockCalled -CommandName Invoke-WebRequest -ParameterFilter {$ContentType -eq 'application/json; charset=utf-8'} -Scope It
             }
 
             It "Uses the -UseBasicParsing switch for Invoke-WebRequest" {
@@ -463,7 +463,7 @@ InModuleScope PSJira {
                 $result | Should Not BeNullOrEmpty
 
                 # Compare each property in the result returned to the expected result
-                foreach ($property in (Get-Member -InputObject $result | ? {$_.MemberType -eq 'NoteProperty'})) {
+                foreach ($property in (Get-Member -InputObject $result | Where-Object {$_.MemberType -eq 'NoteProperty'})) {
                     $result.$property | Should Be $validObjResult.$property
                 }
             }


### PR DESCRIPTION
### Description
Send ContentType as Property of the `Invoke-WebRequest` command instead of inside the Header hashtable

### Motivation and Context
PR #19 described an error
> The 'Content-Type' header must be modified using the appropriate property or method.

because `Invoke-WebRequest` was sending the `content type` in the header of the request.
PR #19  contained the changes necessary, but was never merged back to `dev`/`master`.
Credit goes to @lukhase
closes #19 

### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added Pester Tests that describe what my changes should do.
- [ ] I have updated the documentation accordingly.
